### PR TITLE
This should fix the returned url

### DIFF
--- a/Python_Scripts/OSRM_api_distance_table.py
+++ b/Python_Scripts/OSRM_api_distance_table.py
@@ -11,10 +11,7 @@ def dist_table_url(lats, lons):
     for lat, lon in zip(lats, lons):
         url = url + "loc={" + str(lat) + "," + str(lon) + "}&"
     url = url + "instructions=false"
-    n = len(lats)
-    for ii in range(1,n):
-        url += "&loc=%s,%s" % (str(lats[ii]), lons[ii])
-    return(url)
+        return(url)
         
 def get_dist_table(url, n):
     #url of osrm api call, n is number of verticies


### PR DESCRIPTION
for the dist_table_url function. There was a for loop that duplicated the lats and lons.
